### PR TITLE
bugfix: set correctly degree of polynomial for Shamir sharing.

### DIFF
--- a/src/main/java/threshsig/Dealer.java
+++ b/src/main/java/threshsig/Dealer.java
@@ -158,7 +158,7 @@ public class Dealer {
     BigInteger rand;
     int randbits;
 
-    poly = new Poly(d, k - 1, m);
+    poly = new Poly(d, k, m);
     secrets = new BigInteger[l];
     randbits = n.bitLength() + ThreshUtil.L1 - m.bitLength();
 


### PR DESCRIPTION
To share a secret among k parties, Shamir uses a degree k-1 polynomial (k coefficients). The Poly class takes number of coefficients in its constructor, and not the polynomial degree. This commit fixes an incorrect off-by-one usage of the Poly class.

(Edit to add: the upshot is that k-1 parties alone can reconstruct the secret, instead of the intended k.)